### PR TITLE
Improve package, bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Python package](https://github.com/Felixoid/clickhouse-plantuml/workflows/Python%20package/badge.svg)
+![Python build and test](https://github.com/Felixoid/clickhouse-plantuml/workflows/Python%20build%20and%20test/badge.svg)
 
 # PlantUML generator for ClickHouse tables
 
@@ -97,6 +97,6 @@ And how it looks after running PlantUML:
 ## Usage
 
 ```bash
-python setup.py install
+pip install clickhouse-plantuml
 clickhouse-plantuml
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Python build and test](https://github.com/Felixoid/clickhouse-plantuml/workflows/Python%20build%20and%20test/badge.svg)
+[![PyPI version](https://img.shields.io/pypi/v/clickhouse-plantuml)](https://pypi.org/project/clickhouse-plantuml/)
 
 # PlantUML generator for ClickHouse tables
 

--- a/clickhouse_plantuml/__main__.py
+++ b/clickhouse_plantuml/__main__.py
@@ -23,7 +23,7 @@ from pprint import pformat
 from subprocess import PIPE, Popen
 
 from . import Client, Tables
-from .plantuml import plantuml_tables
+from .plantuml import DiagramConfig, plantuml_tables
 
 logger = logging.getLogger("clickhouse-plantuml")
 formatter = logging.Formatter("%(levelname)-8s [%(filename)s:%(lineno)d]:\n%(message)s")
@@ -147,6 +147,20 @@ def parse_args() -> Namespace:
         "`plantuml-format`. If omitted, the default name is sha1 hexdigest "
         "out of diagram content.",
     )
+    diagram.add_argument(
+        "--type-length",
+        type=int,
+        default=80,
+        dest="type_length",
+        help="truncate column type strings longer than this (shows first chars, …, last 3)",
+    )
+    diagram.add_argument(
+        "--comment-length",
+        type=int,
+        default=80,
+        dest="comment_length",
+        help="truncate table comment strings longer than this",
+    )
 
     args = parser.parse_args()
     args.databases = args.databases or ["default"]
@@ -192,7 +206,9 @@ def main():
         "Columns of the first table are %s",
         pformat([c.__dict__ for c in tables[0].columns]),
     )
-    diagram = plantuml_tables(tables)
+    diagram = plantuml_tables(
+        tables, DiagramConfig(args.type_length, args.comment_length)
+    )
     args.text_output.write(diagram)
     if args.text_output is not sys.stdout:
         args.text_output.close()

--- a/clickhouse_plantuml/__main__.py
+++ b/clickhouse_plantuml/__main__.py
@@ -148,6 +148,13 @@ def parse_args() -> Namespace:
         "out of diagram content.",
     )
     diagram.add_argument(
+        "--no-columns",
+        action="store_true",
+        default=False,
+        dest="no_columns",
+        help="omit column listings — useful for overview diagrams of large databases",
+    )
+    diagram.add_argument(
         "--type-length",
         type=int,
         default=80,
@@ -207,7 +214,8 @@ def main():
         pformat([c.__dict__ for c in tables[0].columns]),
     )
     diagram = plantuml_tables(
-        tables, DiagramConfig(args.type_length, args.comment_length)
+        tables,
+        DiagramConfig(args.type_length, args.comment_length, args.no_columns),
     )
     args.text_output.write(diagram)
     if args.text_output is not sys.stdout:

--- a/clickhouse_plantuml/__main__.py
+++ b/clickhouse_plantuml/__main__.py
@@ -57,15 +57,9 @@ def parse_args() -> Namespace:
     )
     clickhouse = parser.add_argument_group("ClickHouse parameters")
     clickhouse.add_argument(
-        "--host",
-        default="localhost",
-        help="ClickHouse server hostname",
-    )
-    clickhouse.add_argument(
-        "--port",
-        default=9000,
-        type=int,
-        help="ClickHouse server hostname",
+        "--url",
+        default="http://localhost:8123",
+        help="ClickHouse HTTP(S) URL. Default port for HTTP is 8123, for HTTPS is 8443.",
     )
     clickhouse.add_argument(
         "-u",
@@ -76,8 +70,8 @@ def parse_args() -> Namespace:
     clickhouse.add_argument(
         "-p",
         "--password",
-        default="",
-        help="ClickHouse username",
+        default=None,
+        help="ClickHouse password (sent as X-ClickHouse-Key header; omitted if not set)",
     )
     clickhouse.add_argument(
         "-d",
@@ -209,9 +203,7 @@ def main():
     log_levels = [logging.CRITICAL, logging.WARN, logging.INFO, logging.DEBUG]
     logger.setLevel(log_levels[min(args.verbose, 3)])
     logger.debug("Arguments are %s", pformat(args.__dict__))
-    client = Client(
-        host=args.host, port=args.port, user=args.user, password=args.password
-    )
+    client = Client(url=args.url, user=args.user, password=args.password)
     tables = Tables(client, args.databases, args.tables, args.exclude_tables)
     logger.debug("Tables are: %s", pformat(list(map(str, tables))))
     if not tables:

--- a/clickhouse_plantuml/__main__.py
+++ b/clickhouse_plantuml/__main__.py
@@ -148,6 +148,14 @@ def parse_args() -> Namespace:
         "out of diagram content.",
     )
     diagram.add_argument(
+        "--exclude-table",
+        action="append",
+        default=[],
+        dest="exclude_tables",
+        metavar="PATTERN",
+        help="exclude tables matching PATTERN, supports glob (e.g. metric_log*). Can be repeated.",
+    )
+    diagram.add_argument(
         "--no-columns",
         action="store_true",
         default=False,
@@ -204,7 +212,7 @@ def main():
     client = Client(
         host=args.host, port=args.port, user=args.user, password=args.password
     )
-    tables = Tables(client, args.databases, args.tables)
+    tables = Tables(client, args.databases, args.tables, args.exclude_tables)
     logger.debug("Tables are: %s", pformat(list(map(str, tables))))
     if not tables:
         logger.critical("There are no tables with given parameters")

--- a/clickhouse_plantuml/client.py
+++ b/clickhouse_plantuml/client.py
@@ -3,26 +3,69 @@
 # License: Apache-2.0
 # Copyright (C) 2020 Mikhail f. Shiryaev
 
-from clickhouse_driver import Client as OriginalClient  # type: ignore
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Iterator
 
 
-class Client(OriginalClient):
+class Client:
     """
-    Wrapper for clickhouse_driver.Client with execute_dict method
+    Minimal ClickHouse HTTP client using stdlib only.
+    Authenticates via X-ClickHouse-User / X-ClickHouse-Key headers to avoid
+    encoding issues with special characters in credentials.
     """
 
-    def execute_dict(self, *args, **kwargs):
-        kwargs["with_column_types"] = True
-        rows, columns = self.execute(*args, **kwargs)
-        result = [{columns[i][0]: v for i, v in enumerate(r)} for r in rows]
-        return result
+    def __init__(self, url: str, user: str = "default", password: str = None):
+        self._url = url.rstrip("/")
+        self._headers = {"X-ClickHouse-User": user}
+        if password is not None:
+            self._headers["X-ClickHouse-Key"] = password
 
-    def execute_iter_dict(self, *args, **kwargs):
-        kwargs["with_column_types"] = True
-        rows = self.execute_iter(*args, **kwargs)
+    def execute_iter_dict(
+        self, query: str, params: Dict[str, Any] = None
+    ) -> Iterator[Dict[str, Any]]:
+        """Execute a query and yield each row as a dict."""
+        if params:
+            query = self._bind(query, params)
+        full_query = query.strip() + " FORMAT JSONEachRow"
+        url = f"{self._url}/?" + urllib.parse.urlencode({"query": full_query})
+        req = urllib.request.Request(url, headers=self._headers)
         try:
-            columns = next(rows)
-        except StopIteration:
-            return
-        for r in rows:
-            yield {columns[i][0]: v for i, v in enumerate(r)}
+            with urllib.request.urlopen(req) as resp:
+                for line in resp:
+                    line = line.strip()
+                    if line:
+                        try:
+                            yield json.loads(line)
+                        except json.JSONDecodeError as e:
+                            raise RuntimeError(
+                                f"Unexpected response from ClickHouse: {line!r}\n"
+                                f"URL: {url}"
+                            ) from e
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(e.read().decode()) from e
+
+    def execute(self, query: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
+        """Execute a query and return the first row as a dict."""
+        return next(iter(self.execute_iter_dict(query, params)), {})
+
+    @staticmethod
+    def _escape(value: str) -> str:
+        """Escape single quotes for SQL string literals."""
+        return value.replace("'", "''")
+
+    def _bind(self, query: str, params: Dict[str, Any]) -> str:
+        """
+        Inline parameter binding for %(name)s placeholders.
+        Tuples become ('a', 'b') IN-clause literals.
+        Scalar strings are single-quoted.
+        """
+        bound = {}
+        for key, val in params.items():
+            if isinstance(val, tuple):
+                bound[key] = "(" + ", ".join(f"'{self._escape(v)}'" for v in val) + ")"
+            else:
+                bound[key] = f"'{self._escape(val)}'"
+        return query % bound

--- a/clickhouse_plantuml/plantuml.py
+++ b/clickhouse_plantuml/plantuml.py
@@ -15,6 +15,7 @@ from .tables import Tables
 class DiagramConfig:
     type_length: int = field(default=80)
     comment_length: int = field(default=80)
+    no_columns: bool = field(default=False)
 
 
 def truncate_type(s: str, max_length: int) -> str:
@@ -126,6 +127,8 @@ def gen_table_engine(table: Table) -> str:
 
 
 def gen_table_columns(table: Table, config: DiagramConfig) -> str:
+    if config.no_columns:
+        return ""
     t = table
     table_keys = ["partition", "sorting", "sampling"]
     if t.sorting_key != t.primary_key:

--- a/clickhouse_plantuml/plantuml.py
+++ b/clickhouse_plantuml/plantuml.py
@@ -3,6 +3,7 @@
 # License: Apache-2.0
 # Copyright (C) 2020 Mikhail f. Shiryaev
 
+from dataclasses import dataclass, field
 from typing import List
 
 from .column import Column
@@ -10,8 +11,29 @@ from .table import Table
 from .tables import Tables
 
 
-def plantuml_tables(tables: Tables):
-    return plantuml_header() + gen_tables(tables) + plantuml_footer()
+@dataclass
+class DiagramConfig:
+    type_length: int = field(default=80)
+    comment_length: int = field(default=80)
+
+
+def truncate_type(s: str, max_length: int) -> str:
+    """Truncate a type string, preserving the last 3 chars as a closing hint."""
+    if len(s) <= max_length:
+        return s
+    return s[: max_length - 4] + "\u2026" + s[-3:]
+
+
+def truncate_comment(s: str, max_length: int) -> str:
+    """Truncate a comment string."""
+    if len(s) <= max_length:
+        return s
+    return s[: max_length - 1] + "\u2026"
+
+
+def plantuml_tables(tables: Tables, config: DiagramConfig = None):
+    config = config or DiagramConfig()
+    return plantuml_header() + gen_tables(tables, config) + plantuml_footer()
 
 
 def plantuml_header():
@@ -37,13 +59,13 @@ def plantuml_header():
     return header
 
 
-def gen_tables(tables: Tables):
+def gen_tables(tables: Tables, config: DiagramConfig):
     """
     Generates the PlantUML source code out of the Tables object
     """
     code = ""
     for t in tables:
-        code += gen_table(t)
+        code += gen_table(t, config)
 
     code += gen_tables_dependencies(tables)
     return code
@@ -53,13 +75,17 @@ def plantuml_footer():
     return "@enduml\n"
 
 
-def gen_table(table: Table) -> str:
+def gen_table(table: Table, config: DiagramConfig) -> str:
     t = table
     # Table header
     code = f"{table_macros(t.engine)}({t}) {{\n"
 
+    if t.comment:
+        code += add_spaces(f"{truncate_comment(t.comment, config.comment_length)}\n")
+        code += add_spaces("==\n")
+
     code += add_spaces(gen_table_engine(t))
-    code += add_spaces(gen_table_columns(t))
+    code += add_spaces(gen_table_columns(t, config))
 
     # Table footer
     code += "}\n\n"
@@ -99,7 +125,7 @@ def gen_table_engine(table: Table) -> str:
     return code
 
 
-def gen_table_columns(table: Table) -> str:
+def gen_table_columns(table: Table, config: DiagramConfig) -> str:
     t = table
     table_keys = ["partition", "sorting", "sampling"]
     if t.sorting_key != t.primary_key:
@@ -108,7 +134,8 @@ def gen_table_columns(table: Table) -> str:
 
     code = "==columns==\n"
     for c in t.columns:
-        code += f"{c.name}: {c.type}{column_keys(c, table_keys)}\n"
+        col_type = truncate_type(c.type, config.type_length)
+        code += f"{c.name}: {col_type}{column_keys(c, table_keys)}\n"
 
     for k in table_keys:
         key_string = getattr(t, f"{k}_key")

--- a/clickhouse_plantuml/table.py
+++ b/clickhouse_plantuml/table.py
@@ -52,6 +52,7 @@ class Table:
         sorting_key: str,
         primary_key: str,
         sampling_key: str,
+        comment: str = "",
     ):
         self.database = database
         self.name = name
@@ -64,6 +65,7 @@ class Table:
         self.sorting_key = sorting_key
         self.primary_key = primary_key
         self.sampling_key = sampling_key
+        self.comment = comment
         self.columns = []  # type: List[Column]
         self.engine_config = []  # type: List[Tuple[str, str]]
         self.replication_config = []  # type: List[Tuple[str, str]]

--- a/clickhouse_plantuml/table.py
+++ b/clickhouse_plantuml/table.py
@@ -71,6 +71,7 @@ class Table:
         self.replication_config = []  # type: List[Tuple[str, str]]
         self._client = None  # type: Optional[Client]
         self.__engine_args = []  # type: List[str]
+        self.__engine_args_raw = []  # type: List[str]
 
     def add_column(self, column: Column):
         """
@@ -106,14 +107,17 @@ class Table:
 
         if hasattr(self, engine_method):
             getattr(self, engine_method)()
+        if self.__engine_args:
+            raw_repr = "(" + ", ".join(self.__engine_args_raw) + ")"
+            self.engine_config.append(("raw", raw_repr))
         delattr(self, "_client")
 
     def _replicated(self):
         """
         Creates and fills :attr:`replication_config` for Replicated* engines
         """
-        self.replication_config.append(("zoo_path", self.__engine_args.pop(0)))
-        self.replication_config.append(("replica", self.__engine_args.pop(0)))
+        self.replication_config.append(("zoo_path", self._pop_engine_arg()))
+        self.replication_config.append(("replica", self._pop_engine_arg()))
 
     def _graphitemergetree(self):
         self._append_engine_config("rollup_config")
@@ -205,7 +209,11 @@ class Table:
 
     def _append_engine_config(self, name):
         "Dangerous method, doesn't check if :attr:`__engine_args` is empty"
-        self.engine_config.append((name, self.__engine_args.pop(0)))
+        self.engine_config.append((name, self._pop_engine_arg()))
+
+    def _pop_engine_arg(self) -> str:
+        "Pops the next engine arg from the parsed list."
+        return self.__engine_args.pop(0)
 
     def _parse_engine_config(self):
         """
@@ -214,6 +222,7 @@ class Table:
         """
         tokens = generate_tokens(StringIO(self.engine_full).readline)
         engine_args = []  # type: List[str]
+        engine_args_raw = []  # type: List[str]
         stack = 0
         for tok in tokens:
             exact_type = tok_name[tok.exact_type]
@@ -237,6 +246,7 @@ class Table:
                 # But this is comming from ClickHouse server,
                 # so we should be safe
                 engine_args.append("")
+                engine_args_raw.append("")
                 continue
             elif exact_type == "STRING":
                 # Get strings from raw config strings
@@ -250,10 +260,13 @@ class Table:
 
             if not engine_args:
                 engine_args.append("")
+                engine_args_raw.append("")
 
             engine_args[-1] += config_element
+            engine_args_raw[-1] += tok.string
 
         self.__engine_args = engine_args
+        self.__engine_args_raw = engine_args_raw
 
     def __str__(self):
         return f"{self.database}.{self.name}"

--- a/clickhouse_plantuml/tables.py
+++ b/clickhouse_plantuml/tables.py
@@ -6,6 +6,7 @@
 import logging
 import re
 from collections.abc import MutableSequence
+from fnmatch import fnmatch
 from typing import Dict, List
 
 from .client import Client
@@ -25,12 +26,15 @@ class Tables(MutableSequence):
         client: Client,
         databases: List[str] = None,
         tables: List[str] = None,
+        exclude_tables: List[str] = None,
     ):
         self.client = client
         self.__list = []  # type: List[Table]
         self.as_dict = {}  # type: Dict[str, Table]
         if databases:
             self._get_tables(databases, tables)
+            if exclude_tables:
+                self._exclude_tables(exclude_tables)
             self._get_columns()
             self._merge_matviews()
 
@@ -70,6 +74,16 @@ class Tables(MutableSequence):
             raise ValueError("Must be an instance of Table")
         self.__list.insert(index, value)
         self.as_dict[str(value)] = value
+
+    def _exclude_tables(self, patterns: List[str]):
+        """
+        Remove tables whose name matches any of the given glob patterns.
+        Exact names (no wildcards) and glob patterns (e.g. metric_log*) are both supported.
+        """
+        to_remove = [t for t in self if any(fnmatch(t.name, p) for p in patterns)]
+        for t in to_remove:
+            logger.debug("Excluding table %s", t)
+            self.remove(t)
 
     def _get_tables(self, databases: List[str], tables: List[str] = None):
         query = """

--- a/clickhouse_plantuml/tables.py
+++ b/clickhouse_plantuml/tables.py
@@ -84,7 +84,8 @@ class Tables(MutableSequence):
                 partition_key,
                 sorting_key,
                 primary_key,
-                sampling_key
+                sampling_key,
+                comment
             FROM system.tables
             WHERE (database IN %(ds)s OR target_database IN %(ds)s)
                 {name_clause}

--- a/clickhouse_plantuml/version.py
+++ b/clickhouse_plantuml/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Software Development :: Documentation",
     "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["clickhouse-driver"]
+dependencies = []
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Software Development :: Documentation",
     "Topic :: Software Development :: Libraries",
+    "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = []
 requires-python = ">=3.10"
@@ -36,6 +37,8 @@ tests = ["pytest", "pytest-docker", "pylint", "black", "isort"]
 
 [project.urls]
 Homepage = "https://github.com/Felixoid/clickhouse-plantuml"
+Source = "https://github.com/Felixoid/clickhouse-plantuml"
+"Bug Tracker" = "https://github.com/Felixoid/clickhouse-plantuml/issues"
 
 [project.scripts]
 clickhouse-plantuml = "clickhouse_plantuml.__main__:main"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# pylint: disable=protected-access
+
+import unittest
+
+from clickhouse_plantuml.client import Client
+
+
+class TestClientBind(unittest.TestCase):
+    def setUp(self):
+        self.client = Client("http://localhost:8123")
+
+    def test_no_password_omits_header(self):
+        client = Client("http://localhost:8123")
+        assert (
+            "X-ClickHouse-Key" not in client._headers
+        )  # pylint: disable=protected-access
+        client = Client("http://localhost:8123", password=None)
+        assert (
+            "X-ClickHouse-Key" not in client._headers
+        )  # pylint: disable=protected-access
+
+    def test_password_sends_header(self):
+        client = Client("http://localhost:8123", password="")
+        assert (
+            client._headers.get("X-ClickHouse-Key") == ""
+        )  # pylint: disable=protected-access
+
+        client = Client("http://localhost:8123", password="secret")
+        assert (
+            client._headers["X-ClickHouse-Key"] == "secret"
+        )  # pylint: disable=protected-access
+
+    def test_bind_scalar(self):
+        result = self.client._bind(  # pylint: disable=protected-access
+            "WHERE db = %(db)s", {"db": "mydb"}
+        )
+        assert result == "WHERE db = 'mydb'"
+
+    def test_bind_tuple(self):
+        result = self.client._bind(  # pylint: disable=protected-access
+            "WHERE db IN %(ds)s", {"ds": ("db1", "db2")}
+        )
+        assert result == "WHERE db IN ('db1', 'db2')"
+
+    def test_bind_scalar_with_quote(self):
+        result = self.client._bind(  # pylint: disable=protected-access
+            "WHERE db = %(db)s", {"db": "string'with'quote"}
+        )
+        assert result == "WHERE db = 'string''with''quote'"
+
+    def test_bind_tuple_with_quote(self):
+        result = self.client._bind(  # pylint: disable=protected-access
+            "WHERE db IN %(ds)s", {"ds": ("normal", "it's")}
+        )
+        assert result == "WHERE db IN ('normal', 'it''s')"
+
+    def test_escape_no_quotes(self):
+        assert Client._escape("plain") == "plain"  # pylint: disable=protected-access
+
+    def test_escape_single_quote(self):
+        assert Client._escape("it's") == "it''s"  # pylint: disable=protected-access
+
+    def test_escape_multiple_quotes(self):
+        assert Client._escape("a'b'c") == "a''b''c"  # pylint: disable=protected-access

--- a/tests/test_plantuml.py
+++ b/tests/test_plantuml.py
@@ -186,6 +186,10 @@ class TestPlantuml(unittest.TestCase):
             "date\n"
         )
 
+    def test_gen_table_columns_no_columns(self):
+        config = DiagramConfig(no_columns=True)
+        assert p.gen_table_columns(self.test_table, config) == ""
+
     def test_key_sign(self):
         assert p.column_key_sign("any random thing") == ""
         sign = "<size:15><&{}></size>"

--- a/tests/test_plantuml.py
+++ b/tests/test_plantuml.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from clickhouse_plantuml import plantuml as p
 from clickhouse_plantuml.plantuml import DiagramConfig
+from clickhouse_plantuml.tables import Tables
 
 
 class DummyColumn(p.Column):
@@ -10,7 +11,7 @@ class DummyColumn(p.Column):
         pass
 
 
-class TestPlantuml(unittest.TestCase):
+class TestPlantuml(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def setUp(self):
         self.test_table_data = {
             "database": "test_database",
@@ -113,6 +114,29 @@ class TestPlantuml(unittest.TestCase):
             "}\n\n"
         )
         self.test_table.comment = ""
+
+    def test_exclude_tables(self):
+        # pylint: disable=protected-access
+        tables = Tables(None)
+        tables.append(self.test_table)
+        extra_data = dict(self.test_table_data)
+        extra_data.update({"name": "metric_log"})
+        tables.append(p.Table(**extra_data))
+        extra_data2 = dict(self.test_table_data)
+        extra_data2.update({"name": "metric_log_1"})
+        tables.append(p.Table(**extra_data2))
+        assert len(tables) == 3
+        # exact match removes only metric_log
+        tables._exclude_tables(["metric_log"])
+        assert len(tables) == 2
+        assert all(t.name != "metric_log" for t in tables)
+        # glob removes metric_log_1
+        tables._exclude_tables(["metric_log*"])
+        assert len(tables) == 1
+        assert tables[0].name == "test_table"
+        # no-op pattern
+        tables._exclude_tables(["nonexistent*"])
+        assert len(tables) == 1
 
     def test_gen_tables_dependencies(self):
         another_table = dict(self.test_table_data)

--- a/tests/test_plantuml.py
+++ b/tests/test_plantuml.py
@@ -150,6 +150,41 @@ class TestPlantuml(unittest.TestCase):
             "replica: replica_name\n"
         )
 
+    def test_gen_table_engine_unknown(self):
+        """Unknown engine: full args surfaced as single raw entry."""
+        data = dict(self.test_table_data)
+        data.update(
+            {
+                "engine": "SomeNewEngine",
+                "engine_full": "SomeNewEngine('param1', plain_expr)",
+            }
+        )
+        table = p.Table(**data)
+        table.parse_engine()
+        assert p.gen_table_engine(table) == (
+            "ENGINE=**SomeNewEngine**\n"
+            "..engine config..\n"
+            "raw: ('param1', plain_expr)\n"
+        )
+
+    def test_gen_table_engine_partial(self):
+        """Known engine with extra args: full args shown in raw."""
+        data = dict(self.test_table_data)
+        data.update(
+            {
+                "engine": "ReplacingMergeTree",
+                "engine_full": "ReplacingMergeTree('version', is_deleted)",
+            }
+        )
+        table = p.Table(**data)
+        table.parse_engine()
+        assert p.gen_table_engine(table) == (
+            "ENGINE=**ReplacingMergeTree**\n"
+            "..engine config..\n"
+            "version: version\n"
+            "raw: ('version', is_deleted)\n"
+        )
+
     @patch.object(p, "column_keys", return_value="")
     def test_gen_table_column(self, _mock_column_keys):
         config = DiagramConfig()

--- a/tests/test_plantuml.py
+++ b/tests/test_plantuml.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from clickhouse_plantuml import plantuml as p
+from clickhouse_plantuml.plantuml import DiagramConfig
 
 
 class DummyColumn(p.Column):
@@ -25,6 +26,7 @@ class TestPlantuml(unittest.TestCase):
             "sorting_key": "date",
             "primary_key": "date",
             "sampling_key": "",
+            "comment": "",
         }
         self.test_table = p.Table(**self.test_table_data)
         self.test_table.parse_engine()
@@ -57,10 +59,13 @@ class TestPlantuml(unittest.TestCase):
     @patch.object(p, "gen_tables_dependencies", return_value="mocked_dependencies")
     @patch.object(p, "gen_table", return_value="mocked_table")
     def test_gen_tables(self, mock_table, mock_dependencies):
+        config = DiagramConfig()
         # The substatements will be testet separately
-        assert p.gen_tables([]) == "mocked_dependencies"
-        assert p.gen_tables(self.test_tables) == ("mocked_table" "mocked_dependencies")
-        mock_table.assert_called_once_with(self.test_table)
+        assert p.gen_tables([], config) == "mocked_dependencies"
+        assert p.gen_tables(self.test_tables, config) == (
+            "mocked_table" "mocked_dependencies"
+        )
+        mock_table.assert_called_once_with(self.test_table, config)
         mock_dependencies.assert_called_with(self.test_tables)
 
     def test_plantuml_footer(self):
@@ -69,14 +74,45 @@ class TestPlantuml(unittest.TestCase):
     @patch.object(p, "gen_table_columns", return_value="mocked_columns\n")
     @patch.object(p, "gen_table_engine", return_value="mocked_engine\n")
     def test_gen_table(self, mock_engine, mock_columns):
-        assert p.gen_table(self.test_table) == (
+        config = DiagramConfig()
+        assert p.gen_table(self.test_table, config) == (
             "Table(test_database.test_table) {\n"
             "  mocked_engine\n"
             "  mocked_columns\n"
             "}\n\n"
         )
         mock_engine.assert_called_once_with(self.test_table)
-        mock_columns.assert_called_once_with(self.test_table)
+        mock_columns.assert_called_once_with(self.test_table, config)
+
+    @patch.object(p, "gen_table_columns", return_value="mocked_columns\n")
+    @patch.object(p, "gen_table_engine", return_value="mocked_engine\n")
+    def test_gen_table_with_comment(self, _mock_engine, _mock_columns):
+        config = DiagramConfig()
+        self.test_table.comment = "A useful description"
+        assert p.gen_table(self.test_table, config) == (
+            "Table(test_database.test_table) {\n"
+            "  A useful description\n"
+            "  ==\n"
+            "  mocked_engine\n"
+            "  mocked_columns\n"
+            "}\n\n"
+        )
+        self.test_table.comment = ""
+
+    @patch.object(p, "gen_table_columns", return_value="mocked_columns\n")
+    @patch.object(p, "gen_table_engine", return_value="mocked_engine\n")
+    def test_gen_table_with_comment_truncated(self, _mock_engine, _mock_columns):
+        config = DiagramConfig(comment_length=10)
+        self.test_table.comment = "A very long description that should be truncated"
+        assert p.gen_table(self.test_table, config) == (
+            "Table(test_database.test_table) {\n"
+            "  A very lo\u2026\n"
+            "  ==\n"
+            "  mocked_engine\n"
+            "  mocked_columns\n"
+            "}\n\n"
+        )
+        self.test_table.comment = ""
 
     def test_gen_tables_dependencies(self):
         another_table = dict(self.test_table_data)
@@ -116,6 +152,7 @@ class TestPlantuml(unittest.TestCase):
 
     @patch.object(p, "column_keys", return_value="")
     def test_gen_table_column(self, _mock_column_keys):
+        config = DiagramConfig()
         col_date = DummyColumn()
         col_date.__dict__.update(
             {
@@ -137,7 +174,7 @@ class TestPlantuml(unittest.TestCase):
         self.test_table.add_column(col_date)
         self.test_table.add_column(col_str)
         self.test_table.sorting_key = "date, str"
-        assert p.gen_table_columns(self.test_table) == (
+        assert p.gen_table_columns(self.test_table, config) == (
             "==columns==\n"
             "date: Date\n"
             "str: String\n"
@@ -170,3 +207,28 @@ class TestPlantuml(unittest.TestCase):
             " <size:15><&collapse-down></size>"
             " "
         )
+
+    def test_truncate_type(self):
+        # Short string — no truncation
+        assert p.truncate_type("Date", 80) == "Date"
+        # Exactly at limit — no truncation
+        s = "E" * 80
+        assert p.truncate_type(s, 80) == s
+        # Over limit — prefix + … + last 3 chars
+        long_type = "Enum16('SHOW DATABASES' = 0, 'SHOW TABLES' = 1, ...)"
+        result = p.truncate_type(long_type, 20)
+        assert len(result) == 20
+        assert result.endswith(long_type[-3:])
+        assert "\u2026" in result
+
+    def test_truncate_comment(self):
+        # Short string — no truncation
+        assert p.truncate_comment("short", 80) == "short"
+        # Exactly at limit — no truncation
+        s = "x" * 80
+        assert p.truncate_comment(s, 80) == s
+        # Over limit — truncated with …
+        long_comment = "A" * 100
+        result = p.truncate_comment(long_comment, 80)
+        assert len(result) == 80
+        assert result.endswith("\u2026")


### PR DESCRIPTION
- Add comments for tables, limit lenght of columns and comments
- Add `--no-columns` argument for huge DBs and tables
- Add `--exclude-table` argument
- If some of the `engine_config` is unparsed, the full `raw` config is printed
- Fix README
- Get rid of `clickhouse-driver` dependency in favor of stdlib
